### PR TITLE
Changed File Name for backup output to include hostname

### DIFF
--- a/contrib/general/ngf-backup/ngfbackup-as.sh
+++ b/contrib/general/ngf-backup/ngfbackup-as.sh
@@ -30,7 +30,8 @@ TO="[EMAIL-TO]"
 SUBJECT="Backup NextGen Firewall F-Series - $TODAY"
 
 # Backup filename
-FILENAME=NGF-box_`date +%Y_%m_%d_%H_%M`.par
+HOSTNAME=`hostname`
+FILENAME=${HOSTNAME}_`date +%Y_%m_%d_%H_%M`.par
 
 # Creating the log directory
 if [ ! -d "$LOGDIR" ];


### PR DESCRIPTION
Updated filename to include hostname in the backup file - makes it easier to identify when backing up multiple devices to a storage account, while using the same script across all devices.

# Backup filename
HOSTNAME=`hostname`
FILENAME=${HOSTNAME}_`date +%Y_%m_%d_%H_%M`.par