### PR TITLE
Update ipconfig_failover.sh

### DIFF
--- a/contrib/azure/python/multi_ip_object_rewrites/ipconfig_failover.sh
+++ b/contrib/azure/python/multi_ip_object_rewrites/ipconfig_failover.sh
@@ -65,8 +65,8 @@ CONFPATH="/opt/phion/config/active/"
         IP=$(az network nic ip-config list -g $RG --nic-name $NIC --query "[?name=='$NAME'].privateIpAddress" -o tsv)
         echo $IP
 
-    echo "$CONFPATHexternal.boxnet_altip_$NAME.conf" >> $LOG 2>&1
-    echo "IP=$IP" > "$CONFPATHexternal.boxnet_altip_$NAME.conf" 
+    echo "${CONFPATH}external.boxnet_altip_${NAME}.conf" >> $LOG 2>&1
+    echo "IP=$IP" > "${CONFPATH}external.boxnet_altip_${NAME}.conf" 
     echo "Updated network object $FW ruleset to $IP via API " >> $LOG 2>&1
 
     done


### PR DESCRIPTION
Fix interpolation of CONFPATH and make both CONFPATH and NAME be explicitly differentiated from the reset of the quoted text.